### PR TITLE
fix #160 for 2.x

### DIFF
--- a/mybatis-r2dbc/src/main/java/pro/chenggang/project/reactive/mybatis/support/r2dbc/executor/DefaultReactiveMybatisExecutor.java
+++ b/mybatis-r2dbc/src/main/java/pro/chenggang/project/reactive/mybatis/support/r2dbc/executor/DefaultReactiveMybatisExecutor.java
@@ -254,8 +254,11 @@ public class DefaultReactiveMybatisExecutor extends AbstractReactiveMybatisExecu
                                     })
                                     .doOnComplete(() -> {
                                         //clean up reactiveResultHandler
-                                        reactiveResultHandler.cleanup();
                                         r2dbcStatementLog.logTotal(reactiveResultHandler.getResultRowTotalCount());
+                                    })
+                                    .doOnTerminate(() -> {
+                                        //clean up reactiveResultHandler
+                                        reactiveResultHandler.cleanup();
                                     });
                         }));
 

--- a/mybatis-r2dbc/src/main/java/pro/chenggang/project/reactive/mybatis/support/r2dbc/executor/result/handler/DefaultReactiveResultHandler.java
+++ b/mybatis-r2dbc/src/main/java/pro/chenggang/project/reactive/mybatis/support/r2dbc/executor/result/handler/DefaultReactiveResultHandler.java
@@ -66,6 +66,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.stream.Stream;
 
 /**
  * The type Default reactive result handler.
@@ -185,8 +186,7 @@ public class DefaultReactiveResultHandler implements ReactiveResultHandler {
     @SuppressWarnings("unchecked")
     @Override
     public <T> Flux<T> getRemainedResults() {
-        return (Flux<T>) Flux.fromIterable(this.resultHolder)
-                .filter(Objects::nonNull);
+        return (Flux<T>) Flux.fromStream(Stream.of(this.resultHolder.toArray()).filter(Objects::nonNull));
     }
 
     @Override


### PR DESCRIPTION
1. Change the remaining results to a stream of the result array instead of the cached list.
2. Use the common doOnTerminate() operator to clean up the result handler