### PR TITLE
Update dependencies 3x

### DIFF
--- a/mybatis-r2dbc-spring/pom.xml
+++ b/mybatis-r2dbc-spring/pom.xml
@@ -215,6 +215,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
                 <configuration>
+                    <argLine>-XX:+AllowRedefinitionToAddDeleteMethods</argLine>
                     <includes>
                         <include>pro/chenggang/project/reactive/mybatis/support/r2dbc/**/*Tests.java</include>
                     </includes>

--- a/mybatis-r2dbc/pom.xml
+++ b/mybatis-r2dbc/pom.xml
@@ -205,7 +205,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
                 <configuration>
-                    <argLine>-XX:+AllowRedefinitionToAddDeleteMethods</argLine>
                     <includes>
                         <include>pro/chenggang/project/reactive/mybatis/support/r2dbc/**/*Tests.java</include>
                     </includes>

--- a/mybatis-r2dbc/pom.xml
+++ b/mybatis-r2dbc/pom.xml
@@ -205,6 +205,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
                 <configuration>
+                    <argLine>-XX:+AllowRedefinitionToAddDeleteMethods</argLine>
                     <includes>
                         <include>pro/chenggang/project/reactive/mybatis/support/r2dbc/**/*Tests.java</include>
                     </includes>

--- a/pom.xml
+++ b/pom.xml
@@ -68,26 +68,26 @@
         <java.version>11</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <reactor-bom.version>2023.0.1</reactor-bom.version>
-        <r2dbc-mysql.version>1.0.5</r2dbc-mysql.version>
-        <r2dbc-mariadb.version>1.1.4</r2dbc-mariadb.version>
-        <r2dbc-postgresql.version>1.0.3.RELEASE</r2dbc-postgresql.version>
+        <reactor-bom.version>2023.0.11</reactor-bom.version>
+        <r2dbc-mysql.version>1.2.0</r2dbc-mysql.version>
+        <r2dbc-mariadb.version>1.3.0</r2dbc-mariadb.version>
+        <r2dbc-postgresql.version>1.0.7.RELEASE</r2dbc-postgresql.version>
         <r2dbc-mssql.version>1.0.2.RELEASE</r2dbc-mssql.version>
         <oracle-r2dbc.version>1.2.0</oracle-r2dbc.version>
-        <mybatis.version>3.5.13</mybatis.version>
-        <mybatis-spring.version>3.0.3</mybatis-spring.version>
-        <mybatis-freemarker.version>1.2.4</mybatis-freemarker.version>
-        <mybatis-velocity.version>2.1.2</mybatis-velocity.version>
-        <mybatis-thymeleaf.version>1.0.4</mybatis-thymeleaf.version>
+        <mybatis.version>3.5.16</mybatis.version>
+        <mybatis-spring.version>3.0.4</mybatis-spring.version>
+        <mybatis-freemarker.version>1.3.0</mybatis-freemarker.version>
+        <mybatis-velocity.version>2.3.0</mybatis-velocity.version>
+        <mybatis-thymeleaf.version>1.1.0</mybatis-thymeleaf.version>
         <mybatis-generator-core.version>1.4.2</mybatis-generator-core.version>
-        <mybatis-dynamic-sql.version>1.5.0</mybatis-dynamic-sql.version>
-        <lombok.version>1.18.26</lombok.version>
+        <mybatis-dynamic-sql.version>1.5.2</mybatis-dynamic-sql.version>
+        <lombok.version>1.18.34</lombok.version>
         <spring-boot-starter-parent.version>3.0.13</spring-boot-starter-parent.version>
-        <blockhound.version>1.0.8.RELEASE</blockhound.version>
+        <blockhound.version>1.0.10.RELEASE</blockhound.version>
         <junit-jupiter.version>5.10.0</junit-jupiter.version>
-        <testcontainers.version>1.19.3</testcontainers.version>
+        <testcontainers.version>1.20.3</testcontainers.version>
         <assertj.version>3.24.2</assertj.version>
-        <byte-buddy.version>1.14.9</byte-buddy.version>
+        <byte-buddy.version>1.15.7</byte-buddy.version>
         <caffeine.version>3.1.8</caffeine.version>
         <license-maven-plugin.version>4.3</license-maven-plugin.version>
         <slf4j.version>2.0.10</slf4j.version>


### PR DESCRIPTION
Upgrade reactor-bom to version 2023.0.11.
Upgrade r2dbc-mysql to version 1.2.0.
Upgrade r2dbc-mariadb to version 1.3.0.
Upgrade r2dbc-postgresql to version 1.0.7.RELEASE.
Upgrade mybatis to version 3.5.16.
Upgrade mybatis-spring to version 3.0.4.
Upgrade mybatis-freemarker to version 1.3.0.
Upgrade mybatis-velocity to version 2.3.0.
Upgrade mybatis-thymeleaf to version 1.1.0.
Upgrade mybatis-dynamic-sql to version 1.5.2.
Upgrade lombok to version 1.18.34.
Upgrade blockhound to version 1.0.10.RELEASE.
Upgrade testcontainers to version 1.20.3.
Upgrade byte-buddy to version 1.15.7.