### PR TITLE
Switch ProxyInstanceFactory from ByteBuddy to JDK dynamic proxies (fix memory leak)

### DIFF
--- a/mybatis-r2dbc/pom.xml
+++ b/mybatis-r2dbc/pom.xml
@@ -58,10 +58,6 @@
             <artifactId>mybatis</artifactId>
         </dependency>
         <dependency>
-            <groupId>net.bytebuddy</groupId>
-            <artifactId>byte-buddy</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
         </dependency>

--- a/mybatis-r2dbc/src/main/java/pro/chenggang/project/reactive/mybatis/support/r2dbc/support/ProxyInstanceFactory.java
+++ b/mybatis-r2dbc/src/main/java/pro/chenggang/project/reactive/mybatis/support/r2dbc/support/ProxyInstanceFactory.java
@@ -15,12 +15,8 @@
  */
 package pro.chenggang.project.reactive.mybatis.support.r2dbc.support;
 
-import net.bytebuddy.ByteBuddy;
-import net.bytebuddy.implementation.InvocationHandlerAdapter;
-import net.bytebuddy.matcher.ElementMatchers;
-
 import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -58,18 +54,13 @@ public class ProxyInstanceFactory {
         if (null != otherInterfaces && otherInterfaces.length != 0) {
             targetInterfaces.addAll(Arrays.asList(otherInterfaces));
         }
+        InvocationHandler invocationHandler = invocationHandlerSupplier.get();
         try {
-            return (T) new ByteBuddy()
-                    .subclass(Object.class)
-                    .implement(targetInterfaces)
-                    .method(ElementMatchers.isPublic())
-                    .intercept(InvocationHandlerAdapter.of(invocationHandlerSupplier.get()))
-                    .make()
-                    .load(interfaceType.getClassLoader())
-                    .getLoaded()
-                    .getDeclaredConstructor()
-                    .newInstance();
-        } catch (IllegalAccessException | InstantiationException | NoSuchMethodException | InvocationTargetException e) {
+            return (T) Proxy.newProxyInstance(
+                    interfaceType.getClassLoader(),
+                    targetInterfaces.toArray(new Class<?>[0]),
+                    invocationHandler);
+        } catch (IllegalArgumentException e) {
             throw new IllegalStateException("Unable create target interface Proxy Class", e);
         }
     }


### PR DESCRIPTION
## Problem
In an environment running a high volume of queries, the Old gen kept growing and was never reclaimed.

## Cause
ProxyInstanceFactory generates a new ByteBuddy class on every call (random naming, no cache), causing ClassLoader.parallelLockMap to grow unbounded.
Because a randomly-named class is generated on every call with no caching, each generated class adds an entry to parallelLockMap that is never released. The effect was more pronounced the more queries the environment handled.

## Fix
Switch this factory from ByteBuddy to JDK dynamic proxies, consistent with #139 which also uses JDK dynamic proxies. JDK proxies cache the proxy class per interface, so no new class is generated per call, which eliminates the unbounded growth of parallelLockMap.